### PR TITLE
Compile fix Ubuntu 18.04 (link library order and @ char in texinfo file)

### DIFF
--- a/doc/conduits.texi
+++ b/doc/conduits.texi
@@ -33,7 +33,7 @@ are preserved on all copies.
 
 @page
 @vskip 0pt plus 1filll
-Copyright @copyright 2000 Andrew Arensburger.
+Copyright @@copyright 2000 Andrew Arensburger.
 
 Permission is granted to make and distribute verbatim copies of
 this manual provided the copyright notice and this permission notice

--- a/src/Makefile
+++ b/src/Makefile
@@ -68,7 +68,7 @@ OBJS =		${C_OBJS} ${CXX_OBJS} ${CONDUITS_OBJS} \
 
 LIBPCONN = 	-L${TOP}/libpconn -lpconn
 LIBPDB = 	-L${TOP}/libpdb -lpdb
-EXTRA_LIBS =	${LIBPDB} ${LIBPCONN} ${LIBYACC} ${LIBLEX}
+EXTRA_LIBS =	${LIBPDB} ${LIBPCONN} ${LIBYACC} ${LIBLEX} -lusb
 CLEAN =		${CXXPROG} ${OBJS} \
 		*.ln *.bak *~ core *.core .depend \
 		lex.yy.c y.tab.c y.tab.h y.output \


### PR DESCRIPTION
This will fix two problems that prevent the code to build on current Ubuntu distros (and probably other linuxes as well).